### PR TITLE
Jabber.tcpreset.net

### DIFF
--- a/servers.txt
+++ b/servers.txt
@@ -38,6 +38,7 @@ jabbers.one
 jabber.org
 jabber.sk
 jabber.support
+jabber.tcpreset.net
 jabberes.org
 jabberpl.org
 jabjab.de


### PR DESCRIPTION
Hello! The https://jabber.tcpreset.net is the site of the public XMPP server. You can create an account through in-band registration. To do this, use the XMPP clients "Conversations Legacy" for Android devices, "Chatsecure" for iOS, and "Gajim" for linux users.
You can register via browser to this url: https://jabber.tcpreset.net:5280/register 
If you don't want to install any XMPP client application on your computer at all, you can register at https://jabber.tcpreset.net/#converse/register and use Converse.js xmpp web client application.