### PR TITLE
Add NixNet domains & update primary

### DIFF
--- a/servers.txt
+++ b/servers.txt
@@ -94,7 +94,7 @@ neko.im
 netwhood.online
 niel.site
 ninja.im
-nixnet.xyz
+nixnet.services
 no-bullchat.net
 nologs.club
 omemo.im

--- a/servers.txt
+++ b/servers.txt
@@ -81,6 +81,7 @@ laberzentrale.de
 lethyro.net
 lightwitch.org
 lime2.su
+linux.monster
 linuxcult.net
 linuxlovers.at
 magicbroccoli.de
@@ -102,9 +103,11 @@ og.im
 pad7.de
 pad7.net
 quicksy.im
+paranoid.network
 parloteo.es
 planetjabber.de
 pimux.de
+pwned.life
 renntwiesau.de
 riseup.net
 sqli.io 


### PR DESCRIPTION
`nixnet.xyz` was moved to `nixnet.services` quite a while ago, so 9288ceedc6457ae30c900a45e890b5b993d27534 reflects that change. 63ab669d1686afe160cbdee58166b009b384041b adds additional domains for NixNet's XMPP service.
https://docs.nixnet.services/XMPP